### PR TITLE
Fix #21876 Update learner-groups-tab.component.css

### DIFF
--- a/core/templates/pages/learner-dashboard-page/learner-groups-tab.component.css
+++ b/core/templates/pages/learner-dashboard-page/learner-groups-tab.component.css
@@ -214,6 +214,21 @@
 .view-learner-group-invitation-modal .modal-body .mat-radio-button {
   display: unset;
 }
+.learner-groups-tab .invited-to-learner-groups-section.mat-accordion {
+  max-width: 736px; /* Updated max-width */
+}
+
+.learner-groups-tab .mat-expansion-panel.ng-tns-c14-1.ng-star-inserted {
+  max-width: 736px; /* Updated max-width */
+}
+
+.learner-groups-tab .mat-expansion-panel-header.mat-focus-indicator.ng-tns-c15-2.mat-expansion-toggle-indicator-after.ng-star-inserted {
+  max-width: 736px; /* Updated max-width */
+}
+
+.learner-groups-tab .mat-expansion-panel-header-title {
+  max-width: 736px; /* Updated max-width */
+}
 
 @media screen and (max-width: 575px) {
   .learner-groups-tab .oppia-learner-groups-section-title-container {


### PR DESCRIPTION
I have resolved the issue where the "Your Invitation" section did not match the width of the "Your Group" section.

Steps Taken to Solve the Issue:
Inspected the Code: Used DevTools to analyze the styling applied to both sections. Identified Key Classes: Located the relevant CSS classes affecting the width in learner-groups-tab.component.css. Implemented Fix: Updated the CSS by adding the necessary styles under .learner-groups-tab, ensuring consistency across both sections.



1. This PR fixes or fixes part of #[21876].
2. This PR does the following: [Adjusted the div size to match the rest of the dropdowns.
Updated CSS properties (width) for a uniform appearance.
Ensured responsiveness across different screen sizes.
]



<img width="1512" alt="Screenshot 2025-03-04 at 7 51 51 PM" src="https://github.com/user-attachments/assets/c7c2c232-5d90-4f5c-9dbc-f753a5f9cbc2" />
<img width="1512" alt="Screenshot 2025-03-04 at 10 35 44 PM" src="https://github.com/user-attachments/assets/7abb66f8-5dad-4253-b489-c020345a11f8" />
code changed 
<img width="1512" alt="Screenshot 2025-03-04 at 8 01 59 PM" src="https://github.com/user-attachments/assets/738a02c1-74e6-403d-a657-ce32f6f301f4" />

